### PR TITLE
fix: loads sentry on development, disables active_record config

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'rails', '~> 6.0.3', '>= 6.0.3.3'
 gem 'puma', '~> 4.1'
 gem 'octokit', '~> 4.0'
 gem 'rack-cors'
+gem 'sentry-raven'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
@@ -15,10 +16,6 @@ end
 
 group :development do
   gem 'listen', '~> 3.2'
-end
-
-group :production do
-  gem 'sentry-raven'
 end
 
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -29,10 +29,10 @@ Rails.application.configure do
   config.active_support.deprecation = :log
 
   # Raise an error on page load if there are pending migrations.
-  config.active_record.migration_error = :page_load
+  # config.active_record.migration_error = :page_load
 
   # Highlight code that triggered database queries in logs.
-  config.active_record.verbose_query_logs = true
+  # config.active_record.verbose_query_logs = true
 
 
   # Raises error for missing translations.

--- a/test/controllers/api/v1/companies_controller_test.rb
+++ b/test/controllers/api/v1/companies_controller_test.rb
@@ -1,8 +1,11 @@
 require 'test_helper'
+require_relative Rails.root.join('components', 'builtinruby', 'use_cases', 'create_company')
 
-class Api::V1::CompaniesControllerTest < ActionDispatch::IntegrationTest
+class API::V1::CompaniesControllerTest < ActionDispatch::IntegrationTest
   test "should get create" do
-    get api_v1_companies_create_url
+    ::BuiltinRuby::UseCases::CreateCompany.stubs(:call).returns({id: 1})
+
+    post api_v1_companies_url
     assert_response :success
   end
 

--- a/test/controllers/api/v1/home_controller_test.rb
+++ b/test/controllers/api/v1/home_controller_test.rb
@@ -1,8 +1,8 @@
 require 'test_helper'
 
-class Api::V1::HomeControllerTest < ActionDispatch::IntegrationTest
+class API::V1::HomeControllerTest < ActionDispatch::IntegrationTest
   test "should get index" do
-    get api_v1_home_index_url
+    get api_v1_root_url
     assert_response :success
   end
 

--- a/test/controllers/api/v1/jobs_controller_test.rb
+++ b/test/controllers/api/v1/jobs_controller_test.rb
@@ -1,8 +1,12 @@
 require 'test_helper'
+require_relative Rails.root.join('components', 'builtinruby', 'use_cases', 'create_job')
 
-class Api::V1::JobsControllerTest < ActionDispatch::IntegrationTest
+class API::V1::JobsControllerTest < ActionDispatch::IntegrationTest
   test "should get create" do
-    get api_v1_jobs_create_url
+    ::BuiltinRuby::UseCases::CreateJob.stubs(:call).returns({id: 1})
+
+    params = {}
+    post api_v1_jobs_url(params)
     assert_response :success
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,7 +7,8 @@ class ActiveSupport::TestCase
   parallelize(workers: :number_of_processors)
 
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
-  fixtures :all
+  # fixtures :all
 
   # Add more helper methods to be used by all tests here...
+  require 'mocha/minitest'
 end


### PR DESCRIPTION
- Web server was not loading, because Raven was not defined
- ActiveRecord is disabled, so we need to disable related configuration